### PR TITLE
v1.1: 64-byte UART Tx buffer fix

### DIFF
--- a/sync/c.bat
+++ b/sync/c.bat
@@ -1,2 +1,2 @@
-@copy /y syncdev.dot C:\spec\sync\ON\dot\syncdev.
-hdfmonkey.exe put C:\spec\sd207\cspect-next-2gb.img C:\spec\sync\ON\dot\syncdev. dot
+@copy /y syncdev.dot server\dot\syncdev
+

--- a/sync/c.bat
+++ b/sync/c.bat
@@ -1,2 +1,2 @@
-@copy /y syncdev.dot server\dot\syncdev
-
+@copy /y syncdev.dot C:\spec\sync\ON\dot\syncdev.
+hdfmonkey.exe put C:\spec\sd207\cspect-next-2gb.img C:\spec\sync\ON\dot\syncdev. dot

--- a/sync/crt0.s
+++ b/sync/crt0.s
@@ -5,6 +5,7 @@
 		.globl _scr_y
 		.globl _dbg
 		.globl _osiy
+		.globl _corever
 
 		.area _HEADER(ABS)
 _crt0_entry:	
@@ -103,6 +104,7 @@ _mmu4: .db 0
 _scr_x: .db 0
 _scr_y: .db 0
 _dbg: .db 0
+_corever: .word 0
 
 _endof_crt0:
 		;;	(linker documentation:) where specific ordering is desired - 

--- a/sync/crt0.s
+++ b/sync/crt0.s
@@ -93,6 +93,7 @@ allocfail:
 		pop bc
 		pop af
 
+		or a 							; clear CF to indicate success (0 OK) to BASIC
 		
 		ei
 		ret	

--- a/sync/nextsync.c
+++ b/sync/nextsync.c
@@ -486,7 +486,7 @@ void main()
         // Probably asking for help.
         conprint(
            //12345678901234567890123456789012
-            "SYNC v1.1 by Jari Komppa\r"
+            "SYNC v1.2 by Jari Komppa\r"
             "Wifi transfer files from PC\r"
             "\r"
             "SYNOPSIS:\r"
@@ -508,7 +508,8 @@ void main()
         conprint("\r-> ");
         conprint((char*)conffile);
         conprint("\r");
-        filehandle = createfilewithpath((char*)conffile);
+        memcpy((char*)inbuf, (char*)conffile, 27);     // Constants are located below $4000, so copy
+        filehandle = createfilewithpath((char*)inbuf); // filename into temp buffer to keep IDE_PATH happy.
         if (filehandle == 0)
         {
             conprint("Failed to open file\r");
@@ -536,7 +537,7 @@ void main()
           
     SETX(0);
     
-    print("NextSync 1.1 by Jari Komppa");
+    print("NextSync 1.2 by Jari Komppa");
     print("http://iki.fi/sol");
     SETY(scr_y+1);
 

--- a/sync/nextsync.txt
+++ b/sync/nextsync.txt
@@ -1,4 +1,4 @@
-NextSync 1.0
+NextSync 1.1
 by Jari Komppa 2020
 http://iki.fi/sol
 
@@ -383,3 +383,8 @@ Sometimes the esp may just have a brain fart and send kilobytes
 of noise to the z80. This is pretty hard to deal with, so sometimes
 transfers just break, or hang. Often NextSync survives these but
 may take a while.
+
+Next cores 3.01.10 and above have a Tx buffer size of 64 bytes, not
+1 byte. So bytes are accepted faster but still sent at the same rate.
+To preserve previous timings, on 3.01.10+ NextSync waits for all the
+bytes to be sent before continuing.

--- a/sync/nextsync.txt
+++ b/sync/nextsync.txt
@@ -1,4 +1,4 @@
-NextSync 1.1
+NextSync 1.2
 by Jari Komppa 2020
 http://iki.fi/sol
 


### PR DESCRIPTION
When running on 3.01.10 or above, wait for all the bytes in the 64-byte UART Tx buffer to be sent before continuing.